### PR TITLE
RSA Authentication

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "io.rtek.rtvoice"
         minSdkVersion 21
         targetSdkVersion 25
-        versionCode 10
-        versionName "1.0.6"
+        versionCode 11
+        versionName "1.0.7"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "io.rtek.rtvoice"
         minSdkVersion 21
         targetSdkVersion 25
-        versionCode 4
-        versionName "1.0.3"
+        versionCode 10
+        versionName "1.0.6"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "io.rtek.rtvoice"
         minSdkVersion 21
         targetSdkVersion 25
-        versionCode 11
-        versionName "1.0.7"
+        versionCode 12
+        versionName "1.0.8"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-
+    <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />

--- a/app/src/main/java/io/rtek/rtvoice/ControlChannel.java
+++ b/app/src/main/java/io/rtek/rtvoice/ControlChannel.java
@@ -1,5 +1,6 @@
 package io.rtek.rtvoice;
 
+import android.content.res.Resources;
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioRecord;
@@ -14,19 +15,39 @@ import android.util.Log;
 
 import org.apache.http.conn.ssl.SSLSocketFactory;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
+import java.math.BigInteger;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.SecureRandom;
+import java.security.Signature;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -47,6 +68,7 @@ public class ControlChannel extends Thread implements ICallListener {
     BufferedReader in;
     String server;
     Call currentCall;
+    KeyPair identity;
 
     public ControlChannel(IControlChannelListener listener, String server){
         this.listener = listener;
@@ -100,8 +122,6 @@ public class ControlChannel extends Thread implements ICallListener {
         return this.number;
     }
 
-    private int createCall = 0;
-
     public void createIncoming(int number){
         if (!activeCall()) {
             listener.incoming(number);
@@ -119,6 +139,48 @@ public class ControlChannel extends Thread implements ICallListener {
             }
         }).start();
     }
+
+    public void generateIdentity() throws Exception{
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(1024, new SecureRandom());
+        identity = generator.genKeyPair();
+    }
+
+    public String getPublicKey(){
+        return bytesToHex(identity.getPublic().getEncoded());
+    }
+
+    private String getPrivateKey(){
+        return bytesToHex(identity.getPrivate().getEncoded());
+    }
+
+    private void fromKeyPair(String publicKey, String privateKey) throws Exception{
+        byte[] clearPublicKey = hexStringToByteArray(publicKey);
+        byte[] clearPrivateKey = hexStringToByteArray(privateKey);
+        X509EncodedKeySpec spec = new X509EncodedKeySpec(clearPublicKey);
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PublicKey key = keyFactory.generatePublic(spec);
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(clearPrivateKey);
+        KeyFactory fact = KeyFactory.getInstance("RSA");
+        PrivateKey priv = fact.generatePrivate(keySpec);
+        this.identity =  new KeyPair(key, priv);
+    }
+
+    public String encryptRSA(final String publickey, String message) throws Exception{
+        Cipher cipher = Cipher.getInstance("RSA");
+        X509EncodedKeySpec spec = new X509EncodedKeySpec(hexStringToByteArray(publickey));
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PublicKey key = keyFactory.generatePublic(spec);
+        cipher.init(Cipher.ENCRYPT_MODE, key);
+        return bytesToHex(cipher.doFinal(message.getBytes()));
+    }
+
+    public String decryptRSA(String message) throws Exception{
+        Cipher cipher = Cipher.getInstance("RSA");
+        cipher.init(Cipher.DECRYPT_MODE, identity.getPrivate());
+        return new String(cipher.doFinal(hexStringToByteArray(message)));
+    }
+
     Socket socket;
 
     private boolean closing = false;
@@ -130,55 +192,116 @@ public class ControlChannel extends Thread implements ICallListener {
     }
     //Main
     public void run() {
+        try{
+            if(listener.getString("identity-public").isEmpty() || listener.getString("identity-private").isEmpty()){
+                generateIdentity();
+                listener.saveString("identity-public", getPublicKey());
+                listener.saveString("identity-private", getPrivateKey());
+            }else{
+                try{
+                    fromKeyPair(listener.getString("identity-public"), listener.getString("identity-private"));
+                }catch (Exception e){
+                    generateIdentity();
+                    listener.saveString("identity-public", getPublicKey());
+                    listener.saveString("identity-private", getPrivateKey());
+                }
+            }
+        }catch (Exception e) {
+            //Could not generate nor save identity
+        }
         while(!isCancelled()){
             try {
                 listener.ControlChannelDisconnected();
-                Pair<TrustManagerFactory, KeyManagerFactory> km = listener.getTrustManagerFactory();
-                if(km == null || km.first == null || km.second == null){
+                TrustManagerFactory tmf;
+                KeyManagerFactory kmfactory;
+                try{
+                    KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+                    trustStore.load(null);
+                    InputStream stream = listener.getServerCertificate();
+                    BufferedInputStream bis = new BufferedInputStream(stream);
+                    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                    while (bis.available() > 0) {
+                        Certificate cert = cf.generateCertificate(bis);
+                        trustStore.setCertificateEntry("cert" + bis.available(), cert);
+                    }
+                    kmfactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                    kmfactory.init(trustStore, "1234".toCharArray());
+                    tmf=TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                    tmf.init(trustStore);
+                }catch (Exception e){
                     throw new Exception("No valid truststore provided");
                 }
                 SSLContext context = SSLContext.getInstance("SSL");
-                KeyManager[] keymanagers =  km.second.getKeyManagers();
-                context.init(keymanagers, km.first.getTrustManagers(), new SecureRandom());
+                KeyManager[] keymanagers =  kmfactory.getKeyManagers();
+                context.init(keymanagers, tmf.getTrustManagers(), new SecureRandom());
                 socket = context.getSocketFactory().createSocket(this.server, 1338);
                 Log.w("CC", "Connecting");
                 while(!socket.isConnected()){}
-                listener.ControlChannelConnected();
                 Log.w("CC", "Connected");
                 out = new PrintWriter(socket.getOutputStream(), true);
                 in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
 
+                // If no new identity and phone number saved, signed data of current date
+                // If new identity and no saved phone number, send number request and public key to server
+                // If new identity and save password, send authorized key and public key to server
                 String savedNumber = listener.getString("number");
-                if(!savedNumber.isEmpty()){
-                    //Try to register
-                    out.println("REGISTER " + savedNumber.split(":")[0] + " " + savedNumber.split(":")[1]);
-                    String response = in.readLine();
-                    if(response.equals("UNKNOWN NUMBER")){
-                        //Number is unknown, generate new
-                    }else if (response.equals("INVALID KEY")){
-                        //Key was invalid, generate new
-                    }else if (response.equals("ASSOCIATED")){
-                        //All was ok, we can now set number locally
-                        this.number = Integer.parseInt(savedNumber.split(":")[0]);
-                        listener.setNumber(this.number);
-                        if (!listener.getString("gcm").equals("registered")){
-                            if(listener.getGcmDeviceId() != null)
-                                out.println("DEVICE " + listener.getGcmDeviceId());
-                        }
+                if (identity == null){
+                    throw new Exception("RSA not supported on device");
+                }
+
+                //Do auth
+                if (savedNumber.isEmpty()){
+                    //No number saved, request a new one with identity
+                    Log.w("CC", "Requesting new number");
+                    out.println("REQUEST NUMBER " + getPublicKey());
+                }else{
+                    //We have a number, determaine auth method
+                    if (savedNumber.contains(":")){
+                        Log.w("CC", "Registering and upgrading");
+                        //We have a ':' in the number, use authkey method and upgrade number
+                        out.println("REGISTER " + savedNumber.split(":")[0] + " " + savedNumber.split(":")[1] + " " + getPublicKey());
+                    }else{
+                        //We have no ':' in the number, use identity version
+                        //Request random for auth
+                        Log.w("CC", "Requesting random");
+                        out.println("AUTH");
+                        String rnd = in.readLine();
+                        Log.w("CC", "Got random");
+                        out.println("SIG " + savedNumber + " " + signData(rnd));
+                        Log.w("CC", "Auth with RSA " + signData(rnd));
                     }
                 }
 
-                //If no number has been saved
-                if(number == 0){
-                    out.println("REQUEST NUMBER");
-                    String numberKey = in.readLine();
-                    this.number = Integer.parseInt(numberKey.split(" ")[1]);
-                    listener.setNumber(this.number);
-                    Log.w("CC", Integer.toString(number));
-                    listener.saveString("number", numberKey.split(" ")[1] + ":" + numberKey.split(" ")[2]);
-                    out.println("DEVICE " + listener.getGcmDeviceId());
+                //Handle number response
+                String response = in.readLine();
+                if(response.startsWith("NUMBER ")){
+                    Log.w("CC", "Got a new number");
+                    //We got a new number, transmitt our device id
+                    listener.saveString("number", response.split(" ")[1]);
+                    this.number = Integer.parseInt(response.split(" ")[1]);
+                    if(listener.getGcmDeviceId() != null)
+                        out.println("DEVICE " + listener.getGcmDeviceId());
+                }else if(response.equals("ASSOCIATED")){ //If we successfully associated we must have successfully requested an upgrade or successfully authed with our identity
+                    Log.w("CC", "Associated");
+                    //We successfully associated
+                    String current = listener.getString("number");
+                    if (current.contains(":")){
+                        //Remove old auth key
+                        listener.saveString("number", current.split(":")[0]);
+                        this.number = Integer.parseInt(current.split(":")[0]);
+                    }else{
+                        this.number = Integer.parseInt(current);
+                    }
+                    if (!listener.getString("gcm").equals("registered")){
+                        if(listener.getGcmDeviceId() != null)
+                            out.println("DEVICE " + listener.getGcmDeviceId());
+                    }
+                }else{
+                    throw new Exception("Unknown exception when connecting");
                 }
 
+                listener.setNumber(this.number);
+                listener.ControlChannelConnected();
                 while(socket.isConnected() && !isCancelled()){
                     final String cmd = in.readLine();
                     listener.messageReceived(cmd);
@@ -198,14 +321,8 @@ public class ControlChannel extends Thread implements ICallListener {
                     if(cmd.startsWith("LINK ")) {
                         int callerId = Integer.parseInt(cmd.split(" ")[1]);
                         listener.initializeCall(callerId);
-                        String key = "";
-                        if(cmd.split(" ").length == 4){
-                            key = cmd.split(" ")[3];
-                            listener.callSecure(true);
-                        }else{
-                            listener.callSecure(false);
-                        }
-                        currentCall.start(server + ":" + cmd.split(" ")[2], key);
+                        currentCall.start(server + ":" + cmd.split(" ")[2], cmd.split(" ")[3]);
+                        listener.callSecure(true);
                     }
                     if(cmd.startsWith("HANGUP ")){
                         int callerId = Integer.parseInt(cmd.split(" ")[1]);
@@ -236,5 +353,48 @@ public class ControlChannel extends Thread implements ICallListener {
         }
         return;
     }
+
+    public String signData(String message) throws Exception{
+        byte[] data = message.getBytes();
+        Signature sig = Signature.getInstance("SHA256withRSA");
+        sig.initSign(identity.getPrivate());
+        sig.update(data);
+        return bytesToHex(sig.sign());
+    }
+
+    public boolean verifyData(String message, String signature, String publickey) throws Exception{
+        X509EncodedKeySpec spec = new X509EncodedKeySpec(hexStringToByteArray(publickey));
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PublicKey key = keyFactory.generatePublic(spec);
+        byte[] data = message.getBytes();
+        Signature sig = Signature.getInstance("SHA256withRSA");
+        sig.initVerify(key);
+        sig.update(data);
+        return sig.verify(hexStringToByteArray(signature));
+    }
+
+
+    public static byte[] hexStringToByteArray(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                    + Character.digit(s.charAt(i+1), 16));
+        }
+        return data;
+    }
+
+    public static String bytesToHex(byte[] bytes) {
+        char[] hexArray = "0123456789ABCDEF".toCharArray();
+        char[] hexChars = new char[bytes.length * 2];
+        for ( int j = 0; j < bytes.length; j++ ) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+
+
 }
 

--- a/app/src/main/java/io/rtek/rtvoice/IControlChannelListener.java
+++ b/app/src/main/java/io/rtek/rtvoice/IControlChannelListener.java
@@ -2,6 +2,7 @@ package io.rtek.rtvoice;
 
 import android.support.v4.util.Pair;
 
+import java.io.InputStream;
 import java.security.KeyStore;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -23,6 +24,7 @@ public interface IControlChannelListener {
     void saveString(String key, String value);
     void ControlChannelConnected();
     void ControlChannelDisconnected();
-    Pair<TrustManagerFactory, KeyManagerFactory> getTrustManagerFactory();
+
+    InputStream getServerCertificate();
     String getGcmDeviceId();
 }

--- a/app/src/main/java/io/rtek/rtvoice/Main.java
+++ b/app/src/main/java/io/rtek/rtvoice/Main.java
@@ -62,7 +62,7 @@ public class Main extends AppCompatActivity implements IControlChannelListener{
     private Ringtone r;
     MediaPlayer dialingSound;
 
-
+    AssetFileDescriptor afd;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -111,12 +111,12 @@ public class Main extends AppCompatActivity implements IControlChannelListener{
         registerReceiver(receiver, filter);
         try {
             dialingSound = new MediaPlayer();
-            AssetFileDescriptor afd  = getActivity().getAssets().openFd("dialing.wav");
+            afd  = getActivity().getAssets().openFd("dialing.wav");
             dialingSound.setLooping(true);
             dialingSound.setDataSource(afd.getFileDescriptor(),afd.getStartOffset(),afd.getLength());
             dialingSound.setAudioStreamType(AudioManager.STREAM_VOICE_CALL);
             dialingSound.setVolume(0.3F,0.3F);
-        } catch (IOException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -171,7 +171,11 @@ public class Main extends AppCompatActivity implements IControlChannelListener{
                                 mp.start();
                             }
                         });
-                        dialingSound.prepareAsync();
+                        try {
+                            dialingSound.prepareAsync();
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
                     }
                     setInCallView();
                 }

--- a/app/src/main/java/io/rtek/rtvoice/Main.java
+++ b/app/src/main/java/io/rtek/rtvoice/Main.java
@@ -15,6 +15,8 @@ import android.database.Cursor;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.media.Ringtone;
+import android.os.Vibrator;
+
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
@@ -59,6 +61,7 @@ public class Main extends AppCompatActivity implements IControlChannelListener{
     private static int field = 0x00000020;
     private Ringtone r;
     MediaPlayer dialingSound;
+
 
 
     @Override
@@ -262,7 +265,20 @@ public class Main extends AppCompatActivity implements IControlChannelListener{
         final Uri notification = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE);
         r = RingtoneManager.getRingtone(getApplicationContext(), notification);
         r.play();
-
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    while(r.isPlaying()) {
+                        Vibrator v = (Vibrator) main.getSystemService(Context.VIBRATOR_SERVICE);
+                        v.vibrate(1000);
+                        Thread.sleep(5000);
+                    }
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }).start();
         if(isAppIsInBackground(this)) {
             Intent intent = new Intent(this, Main.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/server/Switchboard.java
+++ b/server/Switchboard.java
@@ -24,22 +24,6 @@ public class Switchboard {
             //Create SSLSocket
             SSLServerSocket sslserversocket = (SSLServerSocket) sslContext.getServerSocketFactory().createServerSocket(1338);
 
-            //Backwards compatiability (remove later!!!)
-            //Allow unencrypted on other port (for old clients)
-            new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        ServerSocket serverSocket = new ServerSocket(1337);
-                        while (true){
-                            new VoicePeer(serverSocket.accept()).start();
-                        }
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }   
-                }
-            }).start();     
-            
             while (true){
                 new VoicePeer((SSLSocket) sslserversocket.accept()).start();
             } 


### PR DESCRIPTION
Enhances security by enabling RSA authentication for numbers, old numbers that previously used authentication keys will be automatically upgraded to RSA authentication and the authentication key will be disabled. This makes it harder to gain control of a number as the effective key length is drastically increased and the server-side stored number files no longer contain any sensitive data at all. The private key is only stored on the device that first claimed the number, when that devices storage is cleared there is no way to ever re-use the numbers without wiping the server storage to forget the directory of used numbers. This also opens the ability for the server to request clients to sign additional data associated with a number.

Planned for next update: Have devices store a numbers public key on first contact with that number and reject any other attempts to initialize calls with that number in the future if the public key has been altered. Also allow for two devices to exchange voice encryption keys using these certificates and do visual comparison of the certificates fingerprints.

This version also enhances user experience by adding vibration on incoming calls and dial tones on outgoing calls.